### PR TITLE
chore: unset initial pkg version for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon-advertising-api-nodejs-sdk",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Amazon Advertising API TypeScript and Node.js Unofficial SDK",
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
Semantic release needs version < 1.0.0, as that's the one it starts from.