### PR TITLE
CI: stores polly recordings into the same branch

### DIFF
--- a/.github/workflows/polly.yml
+++ b/.github/workflows/polly.yml
@@ -37,7 +37,7 @@ jobs:
         git config --local user.email "scale-bot@scaleleap.com"
         git config --local user.name "Scale Bot"
         git add -A test/__recordings__
-        git diff-index --quiet HEAD || git commit -m "test: adds Polly recordings"
+        git diff-index --quiet HEAD || git commit -m "test: adds Polly recordings [skip ci]"
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:


### PR DESCRIPTION
Instead of storing recordings on the polly-recordings branch, this will add recordings to the branch you are working on directly.

Just wait for the action to run, and then do a `git pull` to get the latest polly recording.