### PR TITLE
fix: application/x-gzip content type handling

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -193,6 +193,7 @@ export class HttpClient {
     switch (contentType) {
       case JSON_CONTENT_TYPE:
         return bufferToJson(buffer)
+      case 'application/x-gzip':
       case 'application/octet-stream':
         return gunzip(buffer)
           .then(bufferToJson)


### PR DESCRIPTION
Amazon seems to be using "application/x-gzip" content type in addition
to "application/octet-stream".