### PR TITLE
Feat/update campaign types edge case no strategy

### DIFF
--- a/src/operations/campaigns/types.test.ts
+++ b/src/operations/campaigns/types.test.ts
@@ -127,6 +127,23 @@ describe('SponsoredDisplayCampaign', () => {
   })
 })
 
+describe('Campaign Edge Case', () => {
+  it('should allow a non-existent strategy when parsing the bidding parameter', () => {
+    const edgecaseFragment = t.Campaign.decode({
+      campaignId: 108971111858080,
+      name: 'test',
+      campaignType: 'sponsoredProducts',
+      targetingType: 'auto',
+      premiumBidAdjustment: false,
+      dailyBudget: 1,
+      startDate: '20161024',
+      state: 'archived',
+      bidding: { adjustments: [] }
+    });
+    expect(isRight(edgecaseFragment)).toBeTruthy();
+  });
+});
+
 /**
  * TODO: Update test script:
  * SponsoredBrandsCampaign should pass listCampaigns response

--- a/src/operations/campaigns/types.ts
+++ b/src/operations/campaigns/types.ts
@@ -43,10 +43,14 @@ export const CampaignState = t.union([
 ])
 export type CampaignState = t.TypeOf<typeof CampaignState>
 
-export const CampaignBidding = t.type({
-  strategy: CampaignBiddingStrategy,
-  adjustments: CampaignBiddingAdjustments,
-})
+export const CampaignBidding = t.intersection([
+  t.type({
+    adjustments: CampaignBiddingAdjustments
+  }),
+  t.partial({
+    strategy: CampaignBiddingStrategy
+  })
+])
 export type CampaignBidding = t.TypeOf<typeof CampaignBidding>
 
 export const Campaign = t.intersection([


### PR DESCRIPTION
Found an edge case in campaigns returned without a strategy in the bidding element.