### PR TITLE
fix: updating test for adgroups undocumented cases 

### DIFF
--- a/src/operations/ad-groups/types.test.ts
+++ b/src/operations/ad-groups/types.test.ts
@@ -42,3 +42,37 @@ describe('AdGroupResponse', () => {
     expect(isRight(res)).toBeTruthy()
   })
 })
+
+describe('AdGroupExtendedEdgeCase1', () => {
+  it('should pass getAdGroupEx response when servingStatus is "ENDED"', () => {
+    const res = t.AdGroupExtended.decode({
+      adGroupId: 138818764235694,
+      name: 'New Name',
+      campaignId: 31299234922913,
+      defaultBid: 1,
+      state: 'archived',
+      servingStatus: 'ENDED',
+      creationDate: 1550902562000,
+      lastUpdatedDate: 1550904242000,
+    })
+
+    expect(isRight(res)).toBeTruthy()
+  })
+})
+
+describe('AdGroupExtendedEdgeCase2', () => {
+  it('should pass getAdGroupEx response when servingStatus is "AD_GROUP_INCOMPLETE"', () => {
+    const res = t.AdGroupExtended.decode({
+      adGroupId: 138818764235694,
+      name: 'New Name',
+      campaignId: 31299234922913,
+      defaultBid: 1,
+      state: 'archived',
+      servingStatus: 'AD_GROUP_INCOMPLETE',
+      creationDate: 1550902562000,
+      lastUpdatedDate: 1550904242000,
+    })
+
+    expect(isRight(res)).toBeTruthy()
+  })
+})

--- a/src/operations/ad-groups/types.ts
+++ b/src/operations/ad-groups/types.ts
@@ -37,6 +37,7 @@ export type AdGroupResponseStatus = t.TypeOf<typeof AdGroupResponseStatus>
  */
 export const AdGroupServingStatus = t.union([
   t.literal('AD_GROUP_ARCHIVED'),
+  t.literal('AD_GROUP_INCOMPLETE'), // The docs don't mention about this type
   t.literal('AD_GROUP_PAUSED'),
   t.literal('AD_GROUP_STATUS_ENABLED'),
   t.literal('AD_POLICING_SUSPENDED'),
@@ -48,6 +49,7 @@ export const AdGroupServingStatus = t.union([
   t.literal('ADVERTISER_PAYMENT_FAILURE'),
   t.literal('PORTFOLIO_PENDING_START_DATE'), // The docs don't mention about this type
   t.literal('PORTFOLIO_ENDED'), // The docs don't mention about this type
+  t.literal('ENDED'), // The docs don't mention about this type
 ])
 export type AdGroupServingStatus = t.TypeOf<typeof AdGroupServingStatus>
 


### PR DESCRIPTION
fix: updating test for adgroups undocumented cases and expanding AdGroupServingStatus type