### PR TITLE
fix: accept all content type

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -28,7 +28,6 @@ export class HttpClient {
   private get headers(): Headers {
     const headers: Headers = {
       'Content-Type': JSON_CONTENT_TYPE,
-      Accept: JSON_CONTENT_TYPE,
       Authorization: `Bearer ${this.auth.accessToken}`,
       'Amazon-Advertising-API-ClientId': this.auth.clientId,
       'User-Agent': USER_AGENT,


### PR DESCRIPTION
At the moment, [Brands API](https://advertising.amazon.com/API/docs/en-us/sponsored-brands/3-0/openapi#/Brands/getBrands) was returning a custom content type (`application/vnd.brand.v3+json`)

Moreover, they returned an error `NotAcceptableError: No match for accept header`
when we indicates which content types (application/json), our client is able to understand.

This PR indicates our client accept all content type.