### PR TITLE
feat: use agentkeepalive agent for axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,6 +2246,16 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "agentkeepalive": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
+      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "requires": {
+        "debug": "^4.1.0",
+        "depd": "^1.1.2",
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "ajv": {
       "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
@@ -3098,7 +3108,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -3204,8 +3213,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -4628,6 +4636,14 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
+    },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
+      "requires": {
+        "ms": "^2.0.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -7721,8 +7737,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@scaleleap/amazon-marketplaces": "12.0.1",
+    "agentkeepalive": "4.1.4",
     "axios": "0.24.0",
     "client-oauth2": "4.3.3",
     "fp-ts": "2.11.5",

--- a/src/axios.ts
+++ b/src/axios.ts
@@ -1,0 +1,12 @@
+import Axios from 'axios'
+import { USER_AGENT } from './constants'
+import Agent from 'agentkeepalive'
+
+export const axios = Axios.create({
+  httpAgent: new Agent(),
+  headers: {
+    'User-Agent': USER_AGENT,
+  },
+})
+
+export * from 'axios'

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -1,7 +1,7 @@
-import axios, { Method, AxiosResponse } from 'axios'
+import { axios, Method, AxiosResponse } from './axios'
 import HttpStatus from 'http-status-codes'
 
-import { USER_AGENT, JSON_CONTENT_TYPE } from './constants'
+import { JSON_CONTENT_TYPE } from './constants'
 import { apiErrorFactory, NullError, InvalidProgramStateError } from './errors'
 import gunzip from './gunzip'
 import { inspect } from 'util'
@@ -30,7 +30,6 @@ export class HttpClient {
       'Content-Type': JSON_CONTENT_TYPE,
       Authorization: `Bearer ${this.auth.accessToken}`,
       'Amazon-Advertising-API-ClientId': this.auth.clientId,
-      'User-Agent': USER_AGENT,
     }
 
     if (this.auth.scope) {
@@ -193,9 +192,6 @@ export class HttpClient {
 
     const download = await axios.get<ArrayBuffer>(location, {
       responseType: 'arraybuffer',
-      headers: {
-        'User-Agent': USER_AGENT,
-      },
     })
 
     if (download.status !== this.httpStatus.OK) {

--- a/src/o-auth-client.ts
+++ b/src/o-auth-client.ts
@@ -1,10 +1,10 @@
 import ClientOAuth2 from 'client-oauth2'
 import { Options } from 'client-oauth2'
-import axios, { Method } from 'axios'
 import { defaultsDeep } from 'lodash'
 import { USER_AGENT } from './constants'
 import { Marketplace } from './maketplace'
 import type { Headers } from './http-client'
+import { axios, Method } from './axios'
 
 const request: ClientOAuth2.Request = async (
   method,


### PR DESCRIPTION
When running in highly concurrent environment (think AWS Lambda), Axios isn't at it best.

Resulting in many errors: `getaddrinfo EMFILE advertising-api.amazon.com`

This fix uses `agentkeepalive` to keep the connection alive between requests.

See:

- <https://gist.github.com/ccnokes/94576dc38225936a3ca892b989c9d0c6>
- <https://github.com/node-modules/agentkeepalive>
