### PR TITLE
fix: added responses in RecordTypeResponse

### DIFF
--- a/src/operations/snapshots/types.ts
+++ b/src/operations/snapshots/types.ts
@@ -46,6 +46,14 @@ export const RecordTypeResponse = t.union([
   t.literal('campaignNegativeKeyword'),
   t.literal('target'),
   t.literal('negativeTarget'),
+  t.literal('campaigns'),
+  t.literal('adGroups'),
+  t.literal('productAds'),
+  t.literal('keywords'),
+  t.literal('negativeKeywords'),
+  t.literal('campaignNegativeKeywords'),
+  t.literal('targets'),
+  t.literal('negativeTargets'),
 ])
 export type RecordTypeResponse = t.TypeOf<typeof RecordTypeResponse>
 


### PR DESCRIPTION
added responses to fix this this error for Sponsored Display Snapshots

_Invalid value "campaigns" supplied to : (({| snapshotId: string |} & {| status: "SUCCESS" |} & Partial<{ statusDetails: string, location: string, fileSize: number, expiration: DateFromNumber }>) | ({| snapshotId: string |} & {| status: "IN_PROGRESS" |} & Partial<{ statusDetails: string, recordType: ("campaign" | "adGroup" | "productAd" | "keyword" | "negativeKeyword" | "campaignNegativeKeyword" | "target" | "negativeTarget") }>) | ({| snapshotId: string |} & {| status: "FAILURE", statusDetails: string |}))/1: ({| snapshotId: string |} & {| status: "IN_PROGRESS" |} & Partial<{ statusDetails: string, recordType: ("campaign" | "adGroup" | "productAd" | "keyword" | "negativeKeyword" | "campaignNegativeKeyword" | "target" | "negativeTarget") }>)/2: Partial<{ statusDetails: string, recordType: ("campaign" | "adGroup" | "productAd" | "keyword" | "negativeKeyword" | "campaignNegativeKeyword" | "target" | "negativeTarget") }>/recordType: ("campaign" | "adGroup" | "productAd" | "keyword" | "negativeKeyword" | "campaignNegativeKeyword" | "target" | "negativeTarget")/7: "negativeTarget"_