### PR TITLE
fix: error response of createCampaign cannot be parsed

### DIFF
--- a/src/operations/campaigns/types.test.ts
+++ b/src/operations/campaigns/types.test.ts
@@ -107,6 +107,20 @@ describe('CampaignResponse', () => {
     })
     expect(isRight(res)).toBeTruthy()
   })
+
+  it('should pass error response of createCampaigns, updateCampaigns and archiveCampaign', () => {
+    const oldError = t.CampaignResponse.decode({
+      code: 'INVALID_ARGUMENT',
+      details: 'Campaign name is too long',
+    })
+    expect(isRight(oldError)).toBeTruthy()
+
+    const newError = t.CampaignResponse.decode({
+      code: 'INVALID_ARGUMENT',
+      description: ' An entity with that name already exist',
+    })
+    expect(isRight(newError)).toBeTruthy()
+  })
 })
 
 describe('SponsoredDisplayCampaign', () => {

--- a/src/operations/campaigns/types.ts
+++ b/src/operations/campaigns/types.ts
@@ -479,20 +479,25 @@ export type SponsoredBrandsCampaign = t.TypeOf<typeof SponsoredBrandsCampaign>
 export const CampaignResponse = t.intersection([
   t.type({
     /**
-     * The ID of the campaign.
-     */
-    campaignId: CampaignId,
-
-    /**
      * An enumerated success or error code for machine use.
      */
     code: t.string,
   }),
   t.partial({
     /**
+     * The ID of the campaign.
+     */
+    campaignId: CampaignId,
+
+    /**
      * A human-readable description of the error, if unsuccessful.
      */
     details: t.string,
+
+    /**
+     * A human-readable description of the error, if unsuccessful.
+     */
+    description: t.string,
   }),
 ])
 export type CampaignResponse = t.TypeOf<typeof CampaignResponse>

--- a/src/operations/campaigns/types.ts
+++ b/src/operations/campaigns/types.ts
@@ -485,18 +485,15 @@ export const CampaignResponse = t.intersection([
   }),
   t.partial({
     /**
-     * The ID of the campaign.
+     * The ID of the campaign. Available if code is SUCCESS.
      */
     campaignId: CampaignId,
 
     /**
      * A human-readable description of the error, if unsuccessful.
+     * Ads API inconsistently returns details or description between APIs
      */
     details: t.string,
-
-    /**
-     * A human-readable description of the error, if unsuccessful.
-     */
     description: t.string,
   }),
 ])

--- a/test/operations/campaigns/sponsored-products-campaign-operation.test.ts
+++ b/test/operations/campaigns/sponsored-products-campaign-operation.test.ts
@@ -93,7 +93,10 @@ describe('SponsoredProductsCampaignOperation', () => {
 
       expect(createdCampaignResponse.code).toBe('SUCCESS')
 
-      if (createdCampaignResponse.code === 'SUCCESS') {
+      if (
+        createdCampaignResponse.code === 'SUCCESS' &&
+        createdCampaignResponse.campaignId != null
+      ) {
         const res = await campaignOperation.getCampaign(createdCampaignResponse.campaignId)
         expect(res.bidding).toMatchObject(bidding)
       }
@@ -116,6 +119,9 @@ describe('SponsoredProductsCampaignOperation', () => {
           dailyBudget,
         },
       ])
+      if (updateCampaignResponse.code !== 'SUCCESS' || updateCampaignResponse.campaignId == null) {
+        throw new Error('updateCampaign must be successful.')
+      }
       const campaign = await campaignOperation.getCampaign(updateCampaignResponse.campaignId)
 
       expect(campaign.portfolioId).toBe(portfolioId)


### PR DESCRIPTION
Description:
When a campaign fails to create, Ads API returns an error response in the structure below.
```typescript
  {
    "code": "INVALID_ARGUMENT",
    "description": " Campaign name too long"
  }
```

The SDK cannot parse the error, and result an internal error.
```
Failed error DecodeError: Invalid value undefined supplied to : Array<({ campaignId: number, code: string } & Partial<{ details: string, description: string }>)>/0: ({ campaignId: number, code: string } & Partial<{ details: string, description: string }>)/0: { campaignId:
 number, code: string }/campaignId: number
```

