### PR TITLE
fix: NegativeKeywordResponse failed to parse error responses of createNegativeKeywords

### DIFF
--- a/src/operations/keywords/types.test.ts
+++ b/src/operations/keywords/types.test.ts
@@ -80,3 +80,33 @@ describe('SponsoredBrandsKeywordRecommendation', () => {
     expect(isRight(res)).toBeTruthy()
   })
 })
+
+describe('NegativeKeywordResponse', () => {
+  it('should pass SUCCESS createNegativeKeywords response', () => {
+    const res = t.NegativeKeywordResponse.decode({
+      code: 'SUCCESS',
+      keywordId: 59796344109969,
+    })
+
+    expect(isRight(res)).toBeTruthy()
+  })
+
+  it('should pass INVALID_ARGUMENT createNegativeKeywords response with description', () => {
+    const res = t.NegativeKeywordResponse.decode({
+      code: 'INVALID_ARGUMENT',
+      description: 'Targetingclause (keyword) is invalid',
+    })
+
+    expect(isRight(res)).toBeTruthy()
+  })
+
+  it('should pass INVALID_ARGUMENT createNegativeKeywords response with details', () => {
+    const res = t.NegativeKeywordResponse.decode({
+      code: 'INVALID_ARGUMENT',
+      details:
+        'The request input is invalid. Targetingclause (keyword) name is empty Targetingclause (keyword) is invalid',
+    })
+
+    expect(isRight(res)).toBeTruthy()
+  })
+})

--- a/src/operations/keywords/types.ts
+++ b/src/operations/keywords/types.ts
@@ -312,19 +312,21 @@ export type NegativeKeywordExtended = t.TypeOf<typeof NegativeKeywordExtended>
 export const NegativeKeywordResponse = t.intersection([
   t.type({
     /**
-     * The ID of the keyword that was created/updated, if successful
-     */
-    keywordId: KeywordId,
-
-    /**
      * An enumerated success or error code for machine use.
      */
     code: NegativeKeywordResponseStatus,
   }),
   t.partial({
     /**
-     * A human-readable description of the error, if unsuccessful.
+     * The ID of the keyword that was created/updated, if successful
      */
+    keywordId: KeywordId,
+
+    /**
+     * A human-readable description of the error, if unsuccessful.
+     * Ads API returns either description or details.
+     */
+    description: t.string,
     details: t.string,
   }),
 ])


### PR DESCRIPTION
Description:

NegativeKeywordResponse was unable to parse error responses of SponsoredProductsAdGroupNegativeKeywordsOperation.createNegativeKeywords.
```txt
DecodeError: Invalid value undefined supplied to : Array<({ keywordId: number, code: ("SUCCESS" | "INVALID_ARGUMENT" | "NOT_FOUND") } & Partial<{ details: string }>)>/0: ({ keywordId: number, code: ("SUCCESS" | "INVALID_ARGUMENT" | "NOT_FOUND") } & Partial<{ details: string }>)/0: { keywordId: number, code: ("SUCCESS" | "INVALID_ARGUMENT" | "NOT_FOUND") }/keywordId: number at new DecodeError (D:\workspaces\typescript-starters\console-app\node_modules\io-ts-promise\lib\index.js:55:28) at D:\workspaces\typescript-starters\console-app\node_modules\io-ts-promise\lib\index.js:37:76
```

Sample error response:
```json
{
  "code": "INVALID_ARGUMENT",
  "description": " The request input is invalid. Targetingclause (keyword) name is empty Targetingclause (keyword) is invalid"
}
```