### PR TITLE
chore: ignore all peerDependencies when installing

### DIFF
--- a/.github/workflows/polly.yml
+++ b/.github/workflows/polly.yml
@@ -18,7 +18,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '12.x'
+        node-version: '16'
 
     - name: Cache node modules
       uses: actions/cache@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node:
-          - 12
           - 14
           - 16
+          - 18
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
 
       - name: Cache node modules

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 save=true
 save-exact=true
+legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@scaleleap/amazon-advertising-api-sdk",
-      "version": "3.4.3",
+      "version": "3.4.7",
       "license": "MIT",
       "dependencies": {
         "@scaleleap/amazon-marketplaces": "15.0.0",
@@ -15071,8 +15071,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -16408,8 +16407,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-jest": {
       "version": "26.0.0",
@@ -17471,8 +17469,7 @@
     "io-ts": {
       "version": "2.2.16",
       "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-2.2.16.tgz",
-      "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q==",
-      "requires": {}
+      "integrity": "sha512-y5TTSa6VP6le0hhmIyN0dqEXkrZeJLeC5KApJq6VLci3UEKF80lZ+KuoUs02RhBxNWlrqSNxzfI7otLX1Euv8Q=="
     },
     "io-ts-promise": {
       "version": "2.0.2",
@@ -17485,14 +17482,12 @@
     "io-ts-reporters": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/io-ts-reporters/-/io-ts-reporters-1.2.2.tgz",
-      "integrity": "sha512-igASwWWkDY757OutNcM6zTtdJf/eTZYkoe2ymsX2qpm5bKZLo74FJYjsCtMQOEdY7dRHLLEulCyFQwdN69GBCg==",
-      "requires": {}
+      "integrity": "sha512-igASwWWkDY757OutNcM6zTtdJf/eTZYkoe2ymsX2qpm5bKZLo74FJYjsCtMQOEdY7dRHLLEulCyFQwdN69GBCg=="
     },
     "io-ts-types": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/io-ts-types/-/io-ts-types-0.5.16.tgz",
-      "integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ==",
-      "requires": {}
+      "integrity": "sha512-h9noYVfY9rlbmKI902SJdnV/06jgiT2chxG6lYDxaYNp88HscPi+SBCtmcU+m0E7WT5QSwt7sIMj93+qu0FEwQ=="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -19154,8 +19149,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -20895,8 +20889,7 @@
     "popsicle-content-encoding": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-content-encoding/-/popsicle-content-encoding-1.0.0.tgz",
-      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw==",
-      "requires": {}
+      "integrity": "sha512-4Df+vTfM8wCCJVTzPujiI6eOl3SiWQkcZg0AMrOkD1enMXsF3glIkFUZGvour1Sj7jOWCsNSEhBxpbbhclHhzw=="
     },
     "popsicle-cookie-jar": {
       "version": "1.0.0",
@@ -20910,8 +20903,7 @@
     "popsicle-redirects": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/popsicle-redirects/-/popsicle-redirects-1.1.0.tgz",
-      "integrity": "sha512-XCpzVjVk7tty+IJnSdqWevmOr1n8HNDhL86v7mZ6T1JIIf2KGybxUk9mm7ZFOhWMkGB0e8XkacHip7BV8AQWQA==",
-      "requires": {}
+      "integrity": "sha512-XCpzVjVk7tty+IJnSdqWevmOr1n8HNDhL86v7mZ6T1JIIf2KGybxUk9mm7ZFOhWMkGB0e8XkacHip7BV8AQWQA=="
     },
     "popsicle-transport-http": {
       "version": "1.0.8",
@@ -20925,14 +20917,12 @@
     "popsicle-transport-xhr": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/popsicle-transport-xhr/-/popsicle-transport-xhr-1.0.2.tgz",
-      "integrity": "sha512-v9eAJnj1tydT4VmDdyKFE1z/+oL01vB7AS3LfSFMAYv33dzqlxtbApKALcYWBQotIqw3FoIqd2FiDR6qJsOxtA==",
-      "requires": {}
+      "integrity": "sha512-v9eAJnj1tydT4VmDdyKFE1z/+oL01vB7AS3LfSFMAYv33dzqlxtbApKALcYWBQotIqw3FoIqd2FiDR6qJsOxtA=="
     },
     "popsicle-user-agent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/popsicle-user-agent/-/popsicle-user-agent-1.0.0.tgz",
-      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA==",
-      "requires": {}
+      "integrity": "sha512-epKaq3TTfTzXcxBxjpoKYMcTTcAX8Rykus6QZu77XNhJuRHSRxMd+JJrbX/3PFI0opFGSN0BabbAYCbGxbu0mA=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -21534,8 +21524,7 @@
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/setup-polly-jest/-/setup-polly-jest-0.9.1.tgz",
       "integrity": "sha512-BbOxCvMnDHAPG9e3Qw3Ol4/ZWLwnDnhODqrfiIpAtF7Azu0O3PI4svZIfsh+/EV9xNj15LMkvchaWsDvF4A3hQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -22468,9 +22457,9 @@
       "dev": true
     },
     "url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.2.tgz",
+      "integrity": "sha512-6bTUPERy1muxxYClbzoRo5qtQuyoGEbzbQvi0SW4/8U8UyVkAQhWFBlnigqJkRm4su4x1zDQfNbEzWkt+vchcg==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
@@ -22705,8 +22694,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
       "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",


### PR DESCRIPTION
- ignore all peerDependencies when installing
- drop support for Node.js 12