### PR TITLE
feat: enables passing of extra headers to HTTP client

### DIFF
--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -139,46 +139,54 @@ export class HttpClient {
       await this.request({
         ...params,
         uri: this.apiUri(params.uri),
-        headers: this.headers,
+        headers: { ...this.headers, ...params.headers },
       }),
     )
   }
 
-  public async get<T>(resource: string): Promise<T> {
+  public async get<T>(resource: string, extraHeaders: Headers = {}): Promise<T> {
     return this.apiRequest<T>({
       method: 'GET',
       uri: resource,
+      headers: extraHeaders,
     })
   }
 
-  public async put<T>(resource: string, body: RequestBody): Promise<T> {
+  public async put<T>(resource: string, body: RequestBody, extraHeaders: Headers = {}): Promise<T> {
     return this.apiRequest<T>({
       method: 'PUT',
       uri: resource,
       body: JSON.stringify(body),
+      headers: extraHeaders,
     })
   }
 
-  public async post<T>(resource: string, body: RequestBody): Promise<T> {
+  public async post<T>(
+    resource: string,
+    body: RequestBody,
+    extraHeaders: Headers = {},
+  ): Promise<T> {
     return this.apiRequest<T>({
       method: 'POST',
       uri: resource,
       body: JSON.stringify(body),
+      headers: extraHeaders,
     })
   }
 
-  public async delete<T>(resource: string): Promise<T> {
+  public async delete<T>(resource: string, extraHeaders: Headers = {}): Promise<T> {
     return this.apiRequest<T>({
       method: 'DELETE',
       uri: resource,
+      headers: extraHeaders,
     })
   }
 
-  public async download<T>(resource: string): Promise<T> {
+  public async download<T>(resource: string, headers: Headers = {}): Promise<T> {
     const res = await this.request({
       method: 'GET',
       uri: this.apiUri(resource),
-      headers: this.headers,
+      headers: { ...this.headers, ...headers },
     })
 
     // checks for common errors, we don't care about the result, as we expect it to throw


### PR DESCRIPTION
Context: For the latest Advertising APIs, Amazon has moved the version from the uri to contentType. For instance: [SpKeywordRecommendation](https://advertising.amazon.com/API/docs/en-us/sponsored-products/3-0/openapi/prod#/Keyword%20Recommendations/getRankedKeywordRecommendation) has these possible content types
```
Content-Type: application/vnd.spkeywordsrecommendation.v3+json | application/vnd.spkeywordsrecommendation.v4+json | application/vnd.spkeywordsrecommendation.v5+json
```

Problem: A developer who is interested in new APIs cannot extend the SDK, and override the default headers.

Solution: Enable post/put/get/delete methods to accept custom headers. With that, developers can add new operations.
